### PR TITLE
fix AppVeyor Maven build

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,11 +1,19 @@
 environment:
-  MVN_VERSION: 3.3.3
+  MVN_VERSION: 3.3.9
 
 install:
-  - cinst maven --version=%MVN_VERSION% -y
-  - set PATH=C:\tools\apache-maven-%MVN_VERSION%\bin;%PATH%
+  - ps: |
+      Add-Type -AssemblyName System.IO.Compression.FileSystem
+      if (!(Test-Path -Path "C:\maven" )) {
+        (New-Object 'System.Net.WebClient').DownloadFile("http://www.us.apache.org/dist/maven/maven-3/$($env:MVN_VERSION)/binaries/apache-maven-$($env:MVN_VERSION)-bin.zip", "C:\maven-bin.zip")
+        [System.IO.Compression.ZipFile]::ExtractToDirectory("C:\maven-bin.zip", "C:\maven")
+      }
+  - set PATH=C:\maven\apache-maven-%MVN_VERSION%\bin;%PATH%
+  - cmd: mvn --version
+  - cmd: java -version
 
 cache:
+  - C:\maven\
   - C:\Users\appveyor\.m2\repository -> pom.xml
 
 build_script:


### PR DESCRIPTION
- Maven release 3.3.3 is not available on mirrors anymore
- Maven release 3.3.9 is not available with cinst
- manually download and install Maven instead
- thanks to Chenglong Sun <sunchenglong> for the analysis
